### PR TITLE
Remove singleton label from CbSdkConnection

### DIFF
--- a/cerebuswrapper/_shared.py
+++ b/cerebuswrapper/_shared.py
@@ -1,8 +1,0 @@
-def singleton(cls):
-    instances = {}
-
-    def getinstance(**kwargs):
-        if cls not in instances:
-            instances[cls] = cls(**kwargs)
-        return instances[cls]
-    return getinstance

--- a/cerebuswrapper/cbsdkConnection.py
+++ b/cerebuswrapper/cbsdkConnection.py
@@ -1,8 +1,6 @@
 from cerebus import cbpy
-from ._shared import singleton
 
 
-@singleton
 class CbSdkConnection(object):
     def __init__(self, instance=0, con_params=None, simulate_ok=False):
         """


### PR DESCRIPTION
Motivation: connect to more than one NSP at a time.